### PR TITLE
Add WikiMarkdown extension

### DIFF
--- a/httpdocs/README.md
+++ b/httpdocs/README.md
@@ -33,3 +33,14 @@ MediaWiki is the result of global collaboration and cooperation. The CREDITS
 file lists technical contributors to the project. The COPYING file explains
 MediaWiki's copyright and license (GNU General Public License, version 2 or
 later). Many thanks to the Wikimedia community for testing and suggestions.
+## WikiMarkdown extension
+This repository includes the [WikiMarkdown extension](https://www.mediawiki.org/wiki/Extension:WikiMarkdown).
+To fetch the required PHP libraries, run `composer update` from the `httpdocs` directory after ensuring [Composer](https://getcomposer.org/) is available.
+
+Add the following to your `LocalSettings.php` to enable the extension:
+
+```php
+wfLoadExtension( 'WikiMarkdown' );
+$wgAllowMarkdownExtra = true;    // optional, enables Parsedown Extra
+$wgAllowMarkdownExtended = true; // optional, enables Parsedown Extended
+```

--- a/httpdocs/composer.local.json
+++ b/httpdocs/composer.local.json
@@ -1,0 +1,11 @@
+{
+    "extra": {
+        "merge-plugin": {
+            "include": [
+                "extensions/*/composer.json",
+                "extensions/WikiMarkdown/composer.json",
+                "skins/*/composer.json"
+            ]
+        }
+    }
+}

--- a/httpdocs/extensions/WikiMarkdown/LICENSE
+++ b/httpdocs/extensions/WikiMarkdown/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Nathan Kuenzig
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/httpdocs/extensions/WikiMarkdown/README.md
+++ b/httpdocs/extensions/WikiMarkdown/README.md
@@ -1,0 +1,70 @@
+# About
+
+This is a [MediaWiki](https://www.mediawiki.org/) extension that allows for markdown syntax to be used on wiki pages.  More information can be found on the [extension page](https://www.mediawiki.org/wiki/Extension:WikiMarkdown).
+
+# Requirements
+
+This version of the extension has been tested with Parsedown 1.7.4, Parsedown Extra 0.8.1, and MediaWiki 1.35.
+
+# Installation
+
+Add this line to your LocalSettings.php:
+
+```php
+wfLoadExtension( 'WikiMarkdown' );
+```
+
+This extension requires [Parsedown](https://github.com/erusev/parsedown) to be installed and optionally [Parsedown Extra](https://github.com/erusev/parsedown-extra) and [Parsedown Extended](https://github.com/BenjaminHoegh/ParsedownExtended).  Either install them manually, or use Composer by adding the line `"extensions/WikiMarkdown/composer.json"` to the "composer.local.json" file in the root directory of your wiki, e.g.
+```json
+{
+	"extra": {
+		"merge-plugin": {
+			"include": [
+				"extensions/WikiMarkdown/composer.json"
+			]
+		}
+	}
+}
+```
+Then run `composer update` in the root directory of your wiki.
+
+# Usage
+
+On wiki pages, you can now use `<markdown>` elements:
+
+```html
+<markdown>
+## Emphasis
+
+**This is bold text**
+
+__This is bold text__
+
+*This is italic text*
+
+_This is italic text_
+
+~~Strikethrough~~
+</markdown>
+```
+
+# Parameters
+
+* `inline`:   Indicates that inline-style markdown should be used instead of block-style.
+
+# Configuration
+
+* `$wgAllowMarkdownExtra` (optional): Set to `true` in order to specify that [Parsedown Extra](https://github.com/erusev/parsedown-extra) should be used.
+* `$wgAllowMarkdownExtended` (optional): Set to `true` in order to specify that [Parsedown Extended](https://github.com/BenjaminHoegh/ParsedownExtended) should be used.
+* `$wgParsedownExtendedParameters` (optional): Allows for specifying the options that are passed to Parsedown Extended.  See the [documentation](https://benjaminhoegh.github.io/ParsedownExtended/) for which options you want to enable or disable.
+
+# Other Features
+* This extension also functions as a content handler for wiki pages ending in `.md`.  For these pages, the entire page will be interpreted as markdown and markdown syntax highlighting will be used in the editor if you have the [CodeEditor](https://www.mediawiki.org/wiki/Extension:CodeEditor) extension installed.
+* When specifying code blocks in markdown, this extension will automatically apply the [SyntaxHighlight](https://www.mediawiki.org/wiki/Extension:SyntaxHighlight) extension if it is installed.  All languages supported by the SyntaxHighlight extension will work.
+* When using Parsedown Extended, this extension will automatically apply the [Math](https://www.mediawiki.org/wiki/Extension:Math) extension if it is installed to any math blocks by default.  This can be turned off by either not using Parsedown Extended, or modifying `$wgParsedownExtendedParameters`.  The following syntaxes are valid: `\[ ... \]`/`$$ ... $$` (for block mode) and `\( ... \)`/`$ ... $` (for inline mode)
+* When using the [VisualEditor](https://www.mediawiki.org/wiki/Extension:VisualEditor) extension with the CodeEditor extension, markdown blocks will be editable using a markdown editor.
+
+# Credits
+
+* This extension was inspired by the [Markdown Content Handler](https://github.com/brightbyte/MWExtension-Markdown) by Daniel Kinzler and the [Markdown Extension](https://www.mediawiki.org/wiki/Extension:Markdown) by Blake Harley.
+* Parts of this code are based on the [SyntaxHighlight](https://www.mediawiki.org/wiki/Extension:SyntaxHighlight) and [Scribunto](https://www.mediawiki.org/wiki/Extension:Scribunto) extensions.

--- a/httpdocs/extensions/WikiMarkdown/composer.json
+++ b/httpdocs/extensions/WikiMarkdown/composer.json
@@ -1,0 +1,36 @@
+{
+	"name": "mediawiki/wikimarkdown",
+	"description": "Markdown syntax for MediaWiki",
+	"require": {
+		"erusev/parsedown": "^1.8.0-beta-7",
+		"erusev/parsedown-extra": "^0.8.1",
+		"benjaminhoegh/parsedown-extended": "1.1.2"
+	},
+	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "31.0.0",
+		"mediawiki/minus-x": "1.1.0",
+		"php-parallel-lint/php-console-highlighter": "0.5.0",
+		"php-parallel-lint/php-parallel-lint": "1.2.0"
+	},
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Nathan Kuenzig"
+		}
+	],
+	"suggest": {
+		"erusev/parsedown-extra": "Optional extra package",
+		"benjaminhoegh/parsedown-extended": "Optional extra package"
+	},
+	"scripts": {
+		"fix": [
+			"minus-x fix .",
+			"phpcbf"
+		],
+		"test": [
+			"parallel-lint . --exclude vendor --exclude node_modules",
+			"phpcs -p -s",
+			"minus-x check ."
+		]
+	}
+}

--- a/httpdocs/extensions/WikiMarkdown/extension.json
+++ b/httpdocs/extensions/WikiMarkdown/extension.json
@@ -1,0 +1,67 @@
+{
+	"name": "WikiMarkdown",
+	"version": "1.1.3",
+	"author": [
+		"Nathan Kuenzig"
+	],
+	"url": "https://www.mediawiki.org/wiki/Extension:WikiMarkdown",
+	"descriptionmsg": "wikimarkdown-desc",
+	"license-name": "MIT",
+	"type": "parserhook",
+	"requires": {
+		"MediaWiki": ">= 1.34"
+	},
+	"MessagesDirs": {
+		"WikiMarkdown": [
+			"i18n"
+		]
+	},
+	"AutoloadClasses": {
+		"WikiMarkdown": "includes/WikiMarkdown.php",
+		"ResourceLoaderWikiMarkdownVisualEditorModule": "includes/ResourceLoaderWikiMarkdownVisualEditorModule.php",
+		"MarkdownContentHandler": "includes/MarkdownContentHandler.php",
+		"MarkdownContent": "includes/MarkdownContent.php"
+	},
+	"ResourceFileModulePaths": {
+		"localBasePath": "modules",
+		"remoteExtPath": "WikiMarkdown/modules"
+	},
+	"Hooks": {
+		"ParserFirstCallInit": "WikiMarkdown::onParserFirstCallInit",
+		"ResourceLoaderRegisterModules": "WikiMarkdown::onResourceLoaderRegisterModules",
+		"ContentHandlerDefaultModelFor": "WikiMarkdown::onContentHandlerDefaultModelFor",
+		"CodeEditorGetPageLanguage": "WikiMarkdown::onCodeEditorGetPageLanguage"
+	},
+	"attributes": {
+		"VisualEditor": {
+			"PluginModules": [
+				"ext.wikimarkdown.visualEditor"
+			]
+		}
+	},
+	"callback": "WikiMarkdown::onRegistration",
+	"config": {
+		"AllowMarkdownExtra": {
+			"value": false
+		},
+		"AllowMarkdownExtended": {
+			"value": false
+		},
+		"ParsedownExtendedParameters": {
+			"value": {
+				"math": {
+					"single_dollar": true
+				},
+				"sup": true,
+				"sub": true
+			}
+		}
+	},
+	"ContentHandlers": {
+		"markdown": "MarkdownContentHandler"
+	},
+	"TrackingCategories": [
+		"markdown-error-category"
+	],
+	"manifest_version": 2
+}

--- a/httpdocs/extensions/WikiMarkdown/i18n/en.json
+++ b/httpdocs/extensions/WikiMarkdown/i18n/en.json
@@ -1,0 +1,13 @@
+{
+	"@metadata": {
+		"authors": [
+			"Nathan Kuenzig"
+		]
+	},
+	"wikimarkdown-desc": "Provides Markdown syntax <code>&lt;markdown&gt;</code> using [https://parsedown.org/ Parsedown - PHP Markdown Parser]",
+	"markdown-error-category": "Pages with markdown errors",
+	"markdown-error-category-desc": "There was an error when attempting to parse markdown included on the page.",
+	"markdown-visualeditor-mwmarkdowninspector-code": "Code",
+	"markdown-visualeditor-mwmarkdowninspector-title": "Markdown",
+	"markdown-error-parse-failure": "Failed to parse markdown"
+}

--- a/httpdocs/extensions/WikiMarkdown/includes/MarkdownContent.php
+++ b/httpdocs/extensions/WikiMarkdown/includes/MarkdownContent.php
@@ -1,0 +1,46 @@
+<?php
+
+use MediaWiki\MediaWikiServices;
+
+/**
+ * Markdown Content Model
+ */
+class MarkdownContent extends TextContent {
+
+	/**
+	 * @param string $text
+	 */
+	public function __construct( $text ) {
+		parent::__construct( $text, CONTENT_MODEL_MARKDOWN );
+	}
+
+    /**
+	 * Parse the Content object and generate a ParserOutput from the result.
+	 *
+	 * @param Title $title The page title to use as a context for rendering
+	 * @param null|int $revId The revision being rendered (optional)
+	 * @param ParserOptions $options Any parser options
+	 * @param bool $generateHtml Whether to generate HTML (default: true).
+	 * @param ParserOutput &$output ParserOutput representing the HTML form of the text.
+	 * @return ParserOutput
+	 */
+	public function fillParserOutput( Title $title, $revId, ParserOptions $options, $generateHtml, ParserOutput &$output ) {
+        $output = new ParserOutput();
+        if ( !$generateHtml ) {
+			// We don't need the actual HTML
+			$output->setText( '' );
+			return $output;
+		}
+        $wikitext = Html::rawElement(
+            'markdown',
+            [],
+            // Line breaks are needed so that wikitext would be
+            // appropriately isolated for correct parsing.
+            "\n" . $this->getText() . "\n"
+        );
+        $parser = MediaWikiServices::getInstance()->getParser();
+		$output = $parser->parse( $wikitext, $title, $options, true, true, $revId );
+        return $output;
+	}
+
+}

--- a/httpdocs/extensions/WikiMarkdown/includes/MarkdownContentHandler.php
+++ b/httpdocs/extensions/WikiMarkdown/includes/MarkdownContentHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Content handler for the markdown format
+ */
+class MarkdownContentHandler extends TextContentHandler {
+
+    /**
+	 * @param string $modelId
+	 * @param string[] $formats
+	 */
+	public function __construct(
+		$modelId = CONTENT_MODEL_MARKDOWN, $formats = [ CONTENT_FORMAT_MARKDOWN ]
+	) {
+		parent::__construct( $modelId, $formats );
+	}
+
+    /**
+	 * @return string Class name
+	 */
+	protected function getContentClass() {
+		return MarkdownContent::class;
+	}
+
+}

--- a/httpdocs/extensions/WikiMarkdown/includes/ResourceLoaderWikiMarkdownVisualEditorModule.php
+++ b/httpdocs/extensions/WikiMarkdown/includes/ResourceLoaderWikiMarkdownVisualEditorModule.php
@@ -1,0 +1,30 @@
+<?php
+
+class ResourceLoaderWikiMarkdownVisualEditorModule extends ResourceLoaderFileModule {
+
+	protected $targets = [ 'desktop', 'mobile' ];
+
+	/**
+	 * @param ResourceLoaderContext $context
+	 * @return string JavaScript code
+	 */
+	public function getScript( ResourceLoaderContext $context ) {
+		$scripts = parent::getScript( $context );
+
+		return $scripts;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function enableModuleContentVersion() {
+		return true;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function supportsURLLoading() {
+		return false;
+	}
+}

--- a/httpdocs/extensions/WikiMarkdown/includes/WikiMarkdown.php
+++ b/httpdocs/extensions/WikiMarkdown/includes/WikiMarkdown.php
@@ -1,0 +1,335 @@
+<?php
+
+class WikiMarkdown {
+
+	/** @var string CSS class for markdown code. */
+	const MARKDOWN_CSS_CLASS = 'mw-markdown';
+
+	/** @var int Cache version. Increment whenever the HTML changes. */
+	const CACHE_VERSION = 1;
+
+	/**
+	 * Define content handler constant upon extension registration
+	 */
+	public static function onRegistration() {
+		define( 'CONTENT_MODEL_MARKDOWN', 'markdown' );
+		define( 'CONTENT_FORMAT_MARKDOWN', 'text/markdown' );
+	}
+
+	/**
+	 * Register parser hook
+	 *
+	 * @param Parser $parser
+	 */
+	public static function onParserFirstCallInit( Parser $parser ) {
+		$parser->setHook( 'markdown', [ 'WikiMarkdown', 'parserHook' ] );
+	}
+
+	/**
+	 * Parser hook for <markdown> logic
+	 *
+	 * @param string $text
+	 * @param array $args
+	 * @param Parser $parser
+	 * @return string
+	 * @throws MWException
+	 */
+	public static function parserHook( $text, $args, $parser ) {
+		global $wgAllowMarkdownExtended;
+		
+		// Replace strip markers (For e.g. {{#tag:markdown|<nowiki>...}})
+		$out = $parser->getStripState()->unstripNoWiki( $text );
+
+		// Don't trim leading spaces away, just the linefeeds
+		$out = preg_replace( '/^\n+/', '', rtrim( $out ) );
+
+		$result = self::parseMarkdown( $out, $args );
+		if ( !$result->isGood() ) {
+			$parser->addTrackingCategory( 'markdown-error-category' );
+		}
+		$out = $result->getValue();
+
+		// Make it so that tables have borders
+		$out = str_replace('<table>', '<table class="wikitable">', $out);
+		
+		// Format links
+		$out = preg_replace_callback(
+			'/<a\s+href="(.*)">(.*)<\/a>/isU',
+			function ($matches) use (&$parser) {
+				$url = html_entity_decode($matches[1]);
+				$text = html_entity_decode($matches[2]);
+				$linkType = $url == $text ? 'free' : 'text';
+				$cleanUrl = Sanitizer::cleanUrl($url);
+				// Register link in the output object
+				$parser->getOutput()->addExternalLink($url);
+				// Create an external link
+				return Linker::makeExternalLink($cleanUrl, $text, true, $linkType, $parser->getExternalLinkAttribs($url), $parser->getTitle());
+			},
+			$out
+		);
+		
+		// Make html headings into wiki headlines
+		$refers = [];
+		$out = preg_replace_callback(
+			'/<h([1-6])(\s+id="(.*)")?>(.*)<\/h\1>/isU',
+			function ($matches) use (&$refers) {
+				// Create an anchor id from the heading text or id (if found)
+				$anchor = 'markdown_' . (empty($matches[2]) ? Sanitizer::escapeIdForAttribute($matches[4]) : html_entity_decode($matches[3]));
+				// Ensure that anchors are unique
+				if ( isset( $refers[$anchor] ) ) {
+					for ( $i = 2; isset( $refers["{$anchor}_$i"] ); ++$i );
+					$anchor .= "_$i";
+					$refers["{$anchor}_$i"] = true;
+				} else {
+					$refers[$anchor] = true;
+				}
+				return Linker::makeHeadline($matches[1], '>', $anchor, $matches[4], '');
+			},
+			$out
+		);
+		
+		// If SyntaxHighlight is loaded, then use it to perform syntax highlighting
+		if ( ExtensionRegistry::getInstance()->isLoaded( 'SyntaxHighlight' ) ) {
+			$out = preg_replace_callback(
+				'/<pre>\s*<code(\s+class="language-(.*)")?>(.*)<\/code>\s*<\/pre>/isU',
+				function ( $matches ) use ( &$parser ) {
+					// If there's no language, just remove the nested <code> tag
+					if ( empty( $matches[1] ) ) {
+						return '<pre>' . $matches[3] . '</pre>';
+					}
+					// If a language is specified, let SyntaxHighlight handle it
+					$args = array('lang' => $matches[2]);
+					return SyntaxHighlight::parserHook( html_entity_decode( $matches[3] ), $args, $parser );
+				},
+				$out
+			);
+		}
+
+		// If Parsedown Extended is available with tasks turned on, then convert them to OOUI checkboxes
+		if ( $wgAllowMarkdownExtended && ( false !== self::getParsedown()->options['lists']['tasks'] ?? true ) ) {
+			$parser->enableOOUI();
+			$out = preg_replace_callback(
+				'/<input\s+type="checkbox"(.*)>/isU',
+				function ( $matches ) {
+					$check = new \OOUI\CheckboxInputWidget([
+						'disabled' => true,
+						'selected' => in_array('checked', explode(' ', $matches[1]), true)
+					]);
+					return $check->toString();
+				},
+				$out
+			);
+		}
+
+		// If Parsedown Extended is available with math turned on and the Math extension is loaded, then use it to perform math formatting
+		if ( $wgAllowMarkdownExtended && ( false !== self::getParsedown()->options['math'] ?? false ) && ExtensionRegistry::getInstance()->isLoaded( 'Math' ) ) {
+			$out = preg_replace_callback(
+				'/(?<!\\\\)\\\\\[(.*)(?<!\\\\)\\\\\]/isU',
+				function ( $matches ) use ( &$parser ) {
+					$args = array('display' => 'block');
+					return MediaWiki\Extension\Math\Hooks::mathTagHook( html_entity_decode( $matches[1] ), $args, $parser );
+				},
+				$out
+			);
+			$out = preg_replace_callback(
+				'/(?<!\\\\)\$\$(.*)(?<!\\\\)\$\$/isU',
+				function ( $matches ) use ( &$parser ) {
+					$args = array('display' => 'block');
+					return MediaWiki\Extension\Math\Hooks::mathTagHook( html_entity_decode( $matches[1] ), $args, $parser );
+				},
+				$out
+			);
+			$out = preg_replace_callback(
+				'/(?<!\\\\)\\\\\((.*)(?<!\\\\)\\\\\)/isU',
+				function ( $matches ) use ( &$parser ) {
+					$args = array('display' => 'inline');
+					return MediaWiki\Extension\Math\Hooks::mathTagHook( html_entity_decode( $matches[1] ), $args, $parser );
+				},
+				$out
+			);
+			if ( self::getParsedown()->options['math']['single_dollar'] ?? false ) {
+				$out = preg_replace_callback(
+					'/(?<!\\\\)\$(.*)(?<!\\\\)\$/isU',
+					function ( $matches ) use ( &$parser ) {
+						$args = array('display' => 'inline');
+						return MediaWiki\Extension\Math\Hooks::mathTagHook( html_entity_decode( $matches[1] ), $args, $parser );
+					},
+					$out
+				);
+			}
+		}
+		
+		// Allow certain HTML attributes
+		$htmlAttribs = Sanitizer::validateAttributes(
+			$args, array_flip( [ 'style', 'class', 'id', 'dir' ] )
+		);
+		if ( !isset( $htmlAttribs['class'] ) ) {
+			$htmlAttribs['class'] = self::MARKDOWN_CSS_CLASS;
+		} else {
+			$htmlAttribs['class'] .= ' ' . self::MARKDOWN_CSS_CLASS;
+		}
+		if ( isset( $args['inline'] ) ) {
+			// Enforce inlineness. Stray newlines may result in unexpected list and paragraph processing
+			// (also known as doBlockLevels()).
+			$out = str_replace( "\n", ' ', $out );
+			$out = Html::rawElement( 'span', $htmlAttribs, $out );
+
+		} else {
+			// Use 'nowiki' strip marker to prevent list processing (also known as doBlockLevels()).
+			// However, leave the wrapping <div/> outside to prevent <p/>-wrapping.
+			$marker = $parser::MARKER_PREFIX . '-markdowninner-' .
+				sprintf( '%08X', $parser->mMarkerIndex++ ) . $parser::MARKER_SUFFIX;
+			$parser->getStripState()->addNoWiki( $marker, $out );
+			$out = $marker;
+
+			$out = Html::openElement( 'div', $htmlAttribs ) .
+				$out .
+				Html::closeElement( 'div' );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Parse markdown syntax.
+	 *
+	 * This produces raw HTML (wrapped by Status).
+	 *
+	 * @param string $markdown Markdown syntax to parse.
+	 * @param array $args Associative array of additional arguments.
+	 *  If it contains a 'inline' key, the output will not be wrapped in `<div></div>`.
+	 * @return Status Status object, with HTML representing the parsed
+	 *  markdown as its value.
+	 */
+	public static function parseMarkdown( $markdown, $args = [] ) {
+		$status = new Status;
+
+		// For empty tag, output nothing instead of empty <div>.
+		if ( $markdown === '' ) {
+			$status->value = '';
+			return $status;
+		}
+
+		$inline = isset( $args['inline'] );
+
+		$parsedown = static::getParsedown();
+		$parsedown->setSafeMode(true);
+
+		if ( $inline ) {
+			$markdown = trim( $markdown );
+			$output = $parsedown->line( $markdown );
+			$output = trim( $output );
+		} else {
+			$output = $parsedown->text( $markdown );
+		}
+
+		if ( $output === null ) {
+			$status->warning( 'markdown-error-parse-failure' );
+			wfWarn( 'Parsing markdown returned blank output' );
+		}
+
+		$status->value = $output;
+		return $status;
+	}
+
+	/**
+	 * Conditionally register resource loader modules that depends on the
+	 * VisualEditor MediaWiki extension.
+	 *
+	 * @param ResourceLoader $resourceLoader
+	 */
+	public static function onResourceLoaderRegisterModules( $resourceLoader ) {
+		if ( !ExtensionRegistry::getInstance()->isLoaded( 'VisualEditor' ) ) {
+			return;
+		}
+
+		$resourceLoader->register( 'ext.wikimarkdown.visualEditor', [
+			'class' => ResourceLoaderWikiMarkdownVisualEditorModule::class,
+			'localBasePath' => __DIR__ . '/../modules',
+			'remoteExtPath' => 'WikiMarkdown/modules',
+			'scripts' => [
+				've-markdown/ve.dm.MWMarkdownNode.js',
+				've-markdown/ve.dm.MWBlockMarkdownNode.js',
+				've-markdown/ve.dm.MWInlineMarkdownNode.js',
+				've-markdown/ve.ce.MWMarkdownNode.js',
+				've-markdown/ve.ce.MWBlockMarkdownNode.js',
+				've-markdown/ve.ce.MWInlineMarkdownNode.js',
+				've-markdown/ve.ui.MWMarkdownWindow.js',
+				've-markdown/ve.ui.MWMarkdownDialog.js',
+				've-markdown/ve.ui.MWMarkdownDialogTool.js',
+				've-markdown/ve.ui.MWMarkdownInspector.js',
+				've-markdown/ve.ui.MWMarkdownInspectorTool.js',
+			],
+			'styles' => [
+				've-markdown/ve.ce.MWMarkdownNode.css',
+				've-markdown/ve.ui.MWMarkdownDialog.css',
+				've-markdown/ve.ui.MWMarkdownInspector.css',
+			],
+			'dependencies' => [
+				'ext.visualEditor.mwcore',
+				'oojs-ui.styles.icons-editing-advanced'
+			],
+			'messages' => [
+				'markdown-visualeditor-mwmarkdowninspector-code',
+				'markdown-visualeditor-mwmarkdowninspector-title',
+			],
+			'targets' => [ 'desktop', 'mobile' ],
+		] );
+	}
+
+	/**
+	 * Content Handler hook for markdown content pages
+	 *
+	 * @param Title $title Title in question
+	 * @param string &$model Model name. Use with CONTENT_MODEL_XXX constants.
+	 * @return bool|void True or no return value to continue or false to abort
+	 */
+	public static function onContentHandlerDefaultModelFor( Title $title, &$model ) {
+		// Match .md pages.
+		if ( preg_match( '/\.md$/i', $title->getText() ) && $title->isContentPage() ) {
+			$model = CONTENT_MODEL_MARKDOWN;
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param Title $title
+	 * @param string &$languageCode
+	 * @return bool
+	 */
+	public static function onCodeEditorGetPageLanguage( Title $title, &$languageCode ) {
+		if ( !ExtensionRegistry::getInstance()->isLoaded( 'CodeEditor' ) ) {
+			return true;
+		}
+		if ( $title->hasContentModel( CONTENT_MODEL_MARKDOWN ) )
+		{
+			$languageCode = 'markdown';
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * @return Parsedown
+	 */
+	protected static function getParsedown()
+	{
+		static $parsedown;
+		global $wgAllowMarkdownExtra;
+		global $wgAllowMarkdownExtended;
+		global $wgParsedownExtendedParameters;
+
+		if (!$parsedown) {
+			$parsedown = $wgAllowMarkdownExtended
+				? new \ParsedownExtended($wgParsedownExtendedParameters)
+				: ($wgAllowMarkdownExtra
+					? new \ParsedownExtra()
+					: new \Parsedown());
+		}
+
+		return $parsedown;
+	}
+}

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ce.MWBlockMarkdownNode.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ce.MWBlockMarkdownNode.js
@@ -1,0 +1,34 @@
+/*!
+ * VisualEditor ContentEditable MWBlockMarkdownNode class.
+ */
+
+/**
+ * ContentEditable MediaWiki block markdown node.
+ *
+ * @class
+ *
+ * @constructor
+ */
+ve.ce.MWBlockMarkdownNode = function VeCeMWBlockMarkdownNode() {
+	// Parent method
+	ve.ce.MWBlockExtensionNode.super.apply( this, arguments );
+
+	// Mixin method
+	ve.ce.MWMarkdownNode.call( this );
+};
+
+OO.inheritClass( ve.ce.MWBlockMarkdownNode, ve.ce.MWBlockExtensionNode );
+
+OO.mixinClass( ve.ce.MWBlockMarkdownNode, ve.ce.MWMarkdownNode );
+
+ve.ce.MWBlockMarkdownNode.static.name = 'mwBlockMarkdown';
+
+ve.ce.MWBlockMarkdownNode.static.primaryCommandName = 'markdownDialog';
+
+ve.ce.MWBlockMarkdownNode.static.getDescription = function ( model ) {
+	return 'Markdown';
+};
+
+/* Registration */
+
+ve.ce.nodeFactory.register( ve.ce.MWBlockMarkdownNode );

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ce.MWInlineMarkdownNode.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ce.MWInlineMarkdownNode.js
@@ -1,0 +1,35 @@
+/*!
+ * VisualEditor ContentEditable MWInlineMarkdownNode class.
+ */
+
+/**
+ * ContentEditable MediaWiki inline markdown node.
+ *
+ * @class
+ * @abstract
+ *
+ * @constructor
+ */
+ve.ce.MWInlineMarkdownNode = function VeCeMWInlineMarkdownNode() {
+	// Parent method
+	ve.ce.MWInlineExtensionNode.super.apply( this, arguments );
+
+	// Mixin method
+	ve.ce.MWMarkdownNode.call( this );
+};
+
+OO.inheritClass( ve.ce.MWInlineMarkdownNode, ve.ce.MWInlineExtensionNode );
+
+OO.mixinClass( ve.ce.MWInlineMarkdownNode, ve.ce.MWMarkdownNode );
+
+ve.ce.MWInlineMarkdownNode.static.name = 'mwInlineMarkdown';
+
+ve.ce.MWInlineMarkdownNode.static.primaryCommandName = 'markdownInspector';
+
+ve.ce.MWInlineMarkdownNode.static.getDescription = function ( model ) {
+	return 'Inline Markdown';
+};
+
+/* Registration */
+
+ve.ce.nodeFactory.register( ve.ce.MWInlineMarkdownNode );

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ce.MWMarkdownNode.css
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ce.MWMarkdownNode.css
@@ -1,0 +1,8 @@
+/*!
+ * VisualEditor ContentEditable MWMarkdownNode styles.
+ */
+
+.ve-ce-mwMarkdownNode pre {
+	/* Prevent silly wrapping on Safari and Chrome (https://bugs.webkit.org/show_bug.cgi?id=35935) */
+	word-wrap: normal;
+}

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ce.MWMarkdownNode.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ce.MWMarkdownNode.js
@@ -1,0 +1,46 @@
+/*!
+ * VisualEditor ContentEditable MWMarkdownNode class.
+ */
+
+/**
+ * ContentEditable MediaWiki markdown node.
+ *
+ * @class
+ * @abstract
+ *
+ * @constructor
+ */
+ve.ce.MWMarkdownNode = function VeCeMWMarkdownNode() {
+};
+
+/* Inheritance */
+
+OO.initClass( ve.ce.MWMarkdownNode );
+
+/* Static Properties */
+
+ve.ce.MWMarkdownNode.static.name = 'mwMarkdown';
+
+/* Methods */
+
+// Inherits from ve.ce.GeneratedContentNode
+ve.ce.MWMarkdownNode.prototype.generateContents = function () {
+	var node = this,
+		args = arguments;
+	// Parent method
+	return ve.ce.MWExtensionNode.prototype.generateContents.apply( node, args );
+};
+
+// Inherits from ve.ce.BranchNode
+ve.ce.MWMarkdownNode.prototype.onSetup = function () {
+	// Parent method
+	ve.ce.MWExtensionNode.prototype.onSetup.call( this );
+
+	// DOM changes
+	this.$element.addClass( 've-ce-mwMarkdownNode' );
+};
+
+// Inherits from ve.ce.FocusableNode
+ve.ce.MWMarkdownNode.prototype.getBoundingRect = function () {
+	return this.rects[ 0 ];
+};

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.dm.MWBlockMarkdownNode.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.dm.MWBlockMarkdownNode.js
@@ -1,0 +1,30 @@
+/*!
+ * VisualEditor DataModel MWBlockMarkdownNode class.
+ */
+
+/**
+ * DataModel MediaWiki block markdown node.
+ *
+ * @class
+ *
+ * @constructor
+ */
+ve.dm.MWBlockMarkdownNode = function VeDmMWBlockMarkdownNode() {
+	// Parent method
+	ve.dm.MWBlockExtensionNode.super.apply( this, arguments );
+
+	// Mixin method
+	ve.dm.MWMarkdownNode.call( this );
+};
+
+OO.inheritClass( ve.dm.MWBlockMarkdownNode, ve.dm.MWBlockExtensionNode );
+
+OO.mixinClass( ve.dm.MWBlockMarkdownNode, ve.dm.MWMarkdownNode );
+
+ve.dm.MWBlockMarkdownNode.static.name = 'mwBlockMarkdown';
+
+ve.dm.MWBlockMarkdownNode.static.tagName = 'div';
+
+/* Registration */
+
+ve.dm.modelRegistry.register( ve.dm.MWBlockMarkdownNode );

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.dm.MWInlineMarkdownNode.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.dm.MWInlineMarkdownNode.js
@@ -1,0 +1,32 @@
+/*!
+ * VisualEditor DataModel MWInlineMarkdownNode class.
+ */
+
+/**
+ * DataModel MediaWiki inline markdown node.
+ *
+ * @class
+ *
+ * @constructor
+ */
+ve.dm.MWInlineMarkdownNode = function VeDmMWInlineMarkdownNode() {
+	// Parent method
+	ve.dm.MWInlineExtensionNode.super.apply( this, arguments );
+
+	// Mixin method
+	ve.dm.MWMarkdownNode.call( this );
+};
+
+OO.inheritClass( ve.dm.MWInlineMarkdownNode, ve.dm.MWInlineExtensionNode );
+
+OO.mixinClass( ve.dm.MWInlineMarkdownNode, ve.dm.MWMarkdownNode );
+
+ve.dm.MWInlineMarkdownNode.static.name = 'mwInlineMarkdown';
+
+ve.dm.MWInlineMarkdownNode.static.tagName = 'span';
+
+ve.dm.MWInlineMarkdownNode.static.isContent = true;
+
+/* Registration */
+
+ve.dm.modelRegistry.register( ve.dm.MWInlineMarkdownNode );

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.dm.MWMarkdownNode.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.dm.MWMarkdownNode.js
@@ -1,0 +1,42 @@
+/*!
+ * VisualEditor DataModel MWMarkdownNode class.
+ */
+
+/**
+ * DataModel MediaWiki markdown node.
+ *
+ * @class
+ * @abstract
+ *
+ * @constructor
+ */
+ve.dm.MWMarkdownNode = function VeDmMWMarkdownNode() {
+};
+
+/* Inheritance */
+
+OO.initClass( ve.dm.MWMarkdownNode );
+
+/* Static members */
+
+ve.dm.MWMarkdownNode.static.name = 'mwMarkdown';
+
+ve.dm.MWMarkdownNode.static.extensionName = 'markdown';
+
+ve.dm.MWMarkdownNode.static.getMatchRdfaTypes = function () {
+	return [ 'mw:Extension/markdown' ];
+};
+
+/* Static methods */
+
+/**
+ * @inheritdoc
+ */
+ve.dm.MWMarkdownNode.static.toDataElement = function ( domElements, converter ) {
+	// Parent method
+	var isInline = this.isHybridInline( domElements, converter ),
+		type = isInline ? 'mwInlineMarkdown' : 'mwBlockMarkdown',
+		dataElement = ve.dm.MWExtensionNode.static.toDataElement.call( this, domElements, converter, type );
+
+	return dataElement;
+};

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownDialog.css
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownDialog.css
@@ -1,0 +1,16 @@
+/*!
+ * VisualEditor UserInterface MWMarkdownDialog styles.
+ */
+
+.ve-ui-mwMarkdownDialog-content .ve-ui-mwExtensionWindow-input {
+	max-width: none;
+}
+
+.ve-ui-mwMarkdownDialog-content .ve-ui-mwExtensionWindow-input textarea {
+	font-family: monospace, monospace;
+}
+
+.ve-ui-mwMarkdownDialog-content .ve-ui-mwMarkdownWindow-languageField,
+.ve-ui-mwMarkdownDialog-content .ve-ui-mwMarkdownWindow-startLineField {
+	max-width: 30em;
+}

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownDialog.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownDialog.js
@@ -1,0 +1,115 @@
+/*!
+ * VisualEditor UserInterface MWMarkdownDialog class.
+ */
+
+/**
+ * MediaWiki markdown dialog.
+ *
+ * @class
+ * @extends ve.ui.MWExtensionDialog
+ * @mixins ve.ui.MWMarkdownWindow
+ *
+ * @constructor
+ * @param {Object} [config] Configuration options
+ */
+ve.ui.MWMarkdownDialog = function VeUiMWMarkdownDialog() {
+	// Parent constructor
+	ve.ui.MWMarkdownDialog.super.apply( this, arguments );
+
+	// Mixin constructor
+	ve.ui.MWMarkdownWindow.call( this );
+};
+
+/* Inheritance */
+
+OO.inheritClass( ve.ui.MWMarkdownDialog, ve.ui.MWExtensionDialog );
+
+OO.mixinClass( ve.ui.MWMarkdownDialog, ve.ui.MWMarkdownWindow );
+
+/* Static properties */
+
+ve.ui.MWMarkdownDialog.static.name = 'markdownDialog';
+
+ve.ui.MWMarkdownDialog.static.size = 'larger';
+
+ve.ui.MWMarkdownDialog.static.modelClasses = [ ve.dm.MWBlockMarkdownNode ];
+
+/* Methods */
+
+/**
+ * @inheritdoc
+ */
+ve.ui.MWMarkdownDialog.prototype.initialize = function () {
+	// Parent method
+	ve.ui.MWMarkdownDialog.super.prototype.initialize.call( this );
+
+	this.input = new ve.ui.MWAceEditorWidget( {
+		limit: 1,
+		rows: 10,
+		maxRows: 25,
+		autosize: true,
+		autocomplete: 'live',
+		classes: [ 've-ui-mwExtensionWindow-input' ]
+	} );
+
+	this.input.connect( this, { resize: 'updateSize' } );
+
+	// Mixin method
+	ve.ui.MWMarkdownWindow.prototype.initialize.call( this );
+
+	this.contentLayout = new OO.ui.PanelLayout( {
+		scrollable: true,
+		padded: true,
+		expanded: false,
+		content: [
+			this.codeField
+		]
+	} );
+
+	// Initialization
+	this.$content.addClass( 've-ui-mwMarkdownDialog-content' );
+	this.$body.append( this.contentLayout.$element );
+};
+
+/**
+ * @inheritdoc
+ */
+ve.ui.MWMarkdownDialog.prototype.getReadyProcess = function ( data ) {
+	// Parent process
+	var process = ve.ui.MWMarkdownDialog.super.prototype.getReadyProcess.call( this, data );
+	// Mixin process
+	return ve.ui.MWMarkdownWindow.prototype.getReadyProcess.call( this, data, process );
+};
+
+/**
+ * @inheritdoc
+ */
+ve.ui.MWMarkdownDialog.prototype.getSetupProcess = function ( data ) {
+	// Parent process
+	var process = ve.ui.MWMarkdownDialog.super.prototype.getSetupProcess.call( this, data );
+	// Mixin process
+	return ve.ui.MWMarkdownWindow.prototype.getSetupProcess.call( this, data, process )
+		.first( function () {
+			this.input.setup();
+			this.input.setLanguage('markdown');
+		}, this )
+		.next( function () {
+			this.input.clearUndoStack();
+		}, this );
+};
+
+/**
+ * @inheritdoc
+ */
+ve.ui.MWMarkdownDialog.prototype.getTeardownProcess = function ( data ) {
+	// Parent process
+	var process = ve.ui.MWMarkdownDialog.super.prototype.getTeardownProcess.call( this, data );
+	// Mixin process
+	return ve.ui.MWMarkdownWindow.prototype.getTeardownProcess.call( this, data, process ).first( function () {
+		this.input.teardown();
+	}, this );
+};
+
+/* Registration */
+
+ve.ui.windowFactory.register( ve.ui.MWMarkdownDialog );

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownDialogTool.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownDialogTool.js
@@ -1,0 +1,42 @@
+/*!
+ * VisualEditor UserInterface MWMarkdownDialogTool class.
+ */
+
+/**
+ * MediaWiki UserInterface markdown tool.
+ *
+ * @class
+ * @extends ve.ui.FragmentWindowTool
+ * @constructor
+ * @param {OO.ui.ToolGroup} toolGroup
+ * @param {Object} [config] Configuration options
+ */
+ve.ui.MWMarkdownDialogTool = function VeUiMWMarkdownDialogTool() {
+	ve.ui.MWMarkdownDialogTool.super.apply( this, arguments );
+};
+OO.inheritClass( ve.ui.MWMarkdownDialogTool, ve.ui.FragmentWindowTool );
+ve.ui.MWMarkdownDialogTool.static.name = 'markdownDialog';
+ve.ui.MWMarkdownDialogTool.static.group = 'object';
+ve.ui.MWMarkdownDialogTool.static.icon = 'code';
+ve.ui.MWMarkdownDialogTool.static.title = OO.ui.deferMsg(
+	'markdown-visualeditor-mwmarkdowninspector-title' );
+ve.ui.MWMarkdownDialogTool.static.modelClasses = [ ve.dm.MWBlockMarkdownNode ];
+ve.ui.MWMarkdownDialogTool.static.commandName = 'markdownDialog';
+ve.ui.toolFactory.register( ve.ui.MWMarkdownDialogTool );
+
+ve.ui.commandRegistry.register(
+	new ve.ui.Command(
+		'markdownDialog', 'window', 'open',
+		{ args: [ 'markdownDialog' ], supportedSelections: [ 'linear' ] }
+	)
+);
+
+ve.ui.sequenceRegistry.register(
+	// Don't wait for the user to type out the full <markdown> tag
+	new ve.ui.Sequence( 'wikitextMark', 'markdownDialog', '<mark', 5 )
+);
+
+ve.ui.commandHelpRegistry.register( 'insert', 'markdown', {
+	sequences: [ 'wikitextMark' ],
+	label: OO.ui.deferMsg( 'markdown-visualeditor-mwmarkdowninspector-title' )
+} );

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownInspector.css
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownInspector.css
@@ -1,0 +1,11 @@
+/*!
+ * VisualEditor UserInterface MWMarkdownInspector styles.
+ */
+
+.ve-ui-mwMarkdownInspector-content .ve-ui-mwExtensionWindow-input textarea {
+	font-family: monospace, monospace;
+}
+
+.ve-ui-mwMarkdownInspector-content .oo-ui-numberInputWidget {
+	width: 10em;
+}

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownInspector.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownInspector.js
@@ -1,0 +1,86 @@
+/*!
+ * VisualEditor UserInterface MWMarkdownInspector class.
+ */
+
+/**
+ * MediaWiki markdown inspector.
+ *
+ * @class
+ * @extends ve.ui.MWLiveExtensionInspector
+ * @mixins ve.ui.MWMarkdownWindow
+ *
+ * @constructor
+ * @param {Object} [config] Configuration options
+ */
+ve.ui.MWMarkdownInspector = function VeUiMWMarkdownInspector() {
+	// Parent constructor
+	ve.ui.MWMarkdownInspector.super.apply( this, arguments );
+
+	// Mixin constructor
+	ve.ui.MWMarkdownWindow.call( this );
+};
+
+/* Inheritance */
+
+OO.inheritClass( ve.ui.MWMarkdownInspector, ve.ui.MWLiveExtensionInspector );
+
+OO.mixinClass( ve.ui.MWMarkdownInspector, ve.ui.MWMarkdownWindow );
+
+/* Static properties */
+
+ve.ui.MWMarkdownInspector.static.name = 'markdownInspector';
+
+ve.ui.MWMarkdownInspector.static.modelClasses = [ ve.dm.MWInlineMarkdownNode ];
+
+/* Methods */
+
+/**
+ * @inheritdoc
+ */
+ve.ui.MWMarkdownInspector.prototype.initialize = function () {
+	// Parent method
+	ve.ui.MWMarkdownInspector.super.prototype.initialize.call( this );
+
+	// Mixin method
+	ve.ui.MWMarkdownWindow.prototype.initialize.call( this );
+
+	// Initialization
+	this.$content.addClass( 've-ui-mwMarkdownInspector-content' );
+	this.form.$element.prepend(
+		this.codeField.$element
+	);
+};
+
+/**
+ * @inheritdoc
+ */
+ve.ui.MWMarkdownInspector.prototype.getReadyProcess = function ( data ) {
+	// Parent process
+	var process = ve.ui.MWMarkdownInspector.super.prototype.getReadyProcess.call( this, data );
+	// Mixin process
+	return ve.ui.MWMarkdownWindow.prototype.getReadyProcess.call( this, data, process );
+};
+
+/**
+ * @inheritdoc
+ */
+ve.ui.MWMarkdownInspector.prototype.getSetupProcess = function ( data ) {
+	// Parent process
+	var process = ve.ui.MWMarkdownInspector.super.prototype.getSetupProcess.call( this, data );
+	// Mixin process
+	return ve.ui.MWMarkdownWindow.prototype.getSetupProcess.call( this, data, process );
+};
+
+/**
+ * @inheritdoc
+ */
+ve.ui.MWMarkdownInspector.prototype.getTeardownProcess = function ( data ) {
+	// Parent process
+	var process = ve.ui.MWMarkdownInspector.super.prototype.getTeardownProcess.call( this, data );
+	// Mixin process
+	return ve.ui.MWMarkdownWindow.prototype.getTeardownProcess.call( this, data, process );
+};
+
+/* Registration */
+
+ve.ui.windowFactory.register( ve.ui.MWMarkdownInspector );

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownInspectorTool.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownInspectorTool.js
@@ -1,0 +1,33 @@
+/*!
+ * VisualEditor UserInterface MWMarkdownInspectorTool class.
+ */
+
+/**
+ * MediaWiki UserInterface markdown tool.
+ *
+ * @class
+ * @extends ve.ui.FragmentInspectorTool
+ * @constructor
+ * @param {OO.ui.ToolGroup} toolGroup
+ * @param {Object} [config] Configuration options
+ */
+ve.ui.MWMarkdownInspectorTool = function VeUiMWMarkdownInspectorTool() {
+	ve.ui.MWMarkdownInspectorTool.super.apply( this, arguments );
+};
+OO.inheritClass( ve.ui.MWMarkdownInspectorTool, ve.ui.FragmentInspectorTool );
+ve.ui.MWMarkdownInspectorTool.static.name = 'markdownInspector';
+ve.ui.MWMarkdownInspectorTool.static.group = 'object';
+ve.ui.MWMarkdownInspectorTool.static.icon = 'code';
+ve.ui.MWMarkdownInspectorTool.static.title = OO.ui.deferMsg(
+	'markdown-visualeditor-mwmarkdowninspector-title' );
+ve.ui.MWMarkdownInspectorTool.static.modelClasses = [ ve.dm.MWInlineMarkdownNode ];
+ve.ui.MWMarkdownInspectorTool.static.commandName = 'markdownInspector';
+ve.ui.MWMarkdownInspectorTool.static.autoAddToCatchall = false;
+ve.ui.toolFactory.register( ve.ui.MWMarkdownInspectorTool );
+
+ve.ui.commandRegistry.register(
+	new ve.ui.Command(
+		'markdownInspector', 'window', 'open',
+		{ args: [ 'markdownInspector' ], supportedSelections: [ 'linear' ] }
+	)
+);

--- a/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownWindow.js
+++ b/httpdocs/extensions/WikiMarkdown/modules/ve-markdown/ve.ui.MWMarkdownWindow.js
@@ -1,0 +1,66 @@
+/*!
+ * VisualEditor UserInterface MWMarkdownWindow class.
+ */
+
+/**
+ * MediaWiki markdown window.
+ *
+ * @class
+ * @abstract
+ *
+ * @constructor
+ */
+ve.ui.MWMarkdownWindow = function VeUiMWMarkdownWindow() {
+};
+
+/* Inheritance */
+
+OO.initClass( ve.ui.MWMarkdownWindow );
+
+/* Static properties */
+
+ve.ui.MWMarkdownWindow.static.title = OO.ui.deferMsg( 'markdown-visualeditor-mwmarkdowninspector-title' );
+
+ve.ui.MWMarkdownWindow.static.dir = 'ltr';
+
+/* Methods */
+
+/**
+ * @inheritdoc
+ */
+ve.ui.MWMarkdownWindow.prototype.initialize = function () {
+	this.codeField = new OO.ui.FieldLayout( this.input, {
+		align: 'top',
+		label: ve.msg( 'markdown-visualeditor-mwmarkdowninspector-code' )
+	} );
+};
+
+/**
+ * @inheritdoc OO.ui.Window
+ */
+ve.ui.MWMarkdownWindow.prototype.getReadyProcess = function ( data, process ) {
+	return process.next( function () {
+		this.input.focus();
+	}, this );
+};
+
+/**
+ * @inheritdoc OO.ui.Window
+ */
+ve.ui.MWMarkdownWindow.prototype.getSetupProcess = function ( data, process ) {
+	return process;
+};
+
+/**
+ * @inheritdoc OO.ui.Window
+ */
+ve.ui.MWMarkdownWindow.prototype.getTeardownProcess = function ( data, process ) {
+	return process;
+};
+
+/**
+ * @inheritdoc ve.ui.MWExtensionWindow
+ */
+ve.ui.MWMarkdownWindow.prototype.updateActions = function () {
+	this.getActions().setAbilities( { done: this.isModified() } );
+};


### PR DESCRIPTION
## Summary
- add the WikiMarkdown extension from GitHub
- configure composer to pull dependencies for the new extension
- document how to enable WikiMarkdown in README

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7afdd2b083218a482a63a8eec278